### PR TITLE
fix error code on second entry

### DIFF
--- a/rootfs/entrypoint.sh
+++ b/rootfs/entrypoint.sh
@@ -9,8 +9,8 @@ then
     ln -fsv "/usr/share/zoneinfo/${TIMEZONE}" /etc/localtime
 fi
 
-id -g ${GITIT_GID}" &>/dev/null || groupadd -g "${GITIT_GID}" -o "${GITIT_USER}"
-id -u ${GITIT_USER}" &>/dev/null || useradd -g "${GITIT_USER}" -m -o -u "${GITIT_UID}" "${GITIT_USER}"
+id -g "${GITIT_GID}" &>/dev/null || groupadd -g "${GITIT_GID}" -o "${GITIT_USER}"
+id -u "${GITIT_USER}" &>/dev/null || useradd -g "${GITIT_USER}" -m -o -u "${GITIT_UID}" "${GITIT_USER}"
 
 if [ ! -e "${GITIT_CONF}" ]
 then

--- a/rootfs/entrypoint.sh
+++ b/rootfs/entrypoint.sh
@@ -9,8 +9,8 @@ then
     ln -fsv "/usr/share/zoneinfo/${TIMEZONE}" /etc/localtime
 fi
 
-groupadd -g "${GITIT_GID}" -o "${GITIT_USER}"
-useradd -g "${GITIT_USER}" -m -o -u "${GITIT_UID}" "${GITIT_USER}"
+id -g ${GITIT_GID}" &>/dev/null || groupadd -g "${GITIT_GID}" -o "${GITIT_USER}"
+id -u ${GITIT_USER}" &>/dev/null || useradd -g "${GITIT_USER}" -m -o -u "${GITIT_UID}" "${GITIT_USER}"
 
 if [ ! -e "${GITIT_CONF}" ]
 then


### PR DESCRIPTION
Hi! Firstly thanks for making this docker image which make using `gitit` so much easier.

I was using the experimental one, and found out that on second-entry (i.e. after `docker stop` and `docker start`) the container will keep on restarting with some error message about user group.

I found out that it's because of this base image's `groupadd` and `useradd`, of which they will be run everything the container is started.

On first run it will be fine because the user/group does not exists yet. However, if you stop and run again, it will throw errors saying the group already exists, which made the container unable to run again.

This PR add a check to see if those group/user exists and only try to create them if they don't exists.